### PR TITLE
Settings: Allow separating ringer & notification sound streams

### DIFF
--- a/res/values/derp_strings.xml
+++ b/res/values/derp_strings.xml
@@ -902,4 +902,8 @@
 
     <!-- Android Beam -->
     <string name="android_beam_main_switch_title">Use Android Beam</string>
+
+    <!-- Separate ring & notification toggle -->
+    <string name="volume_separate_notification_title">Separated Ring and Notification</string>
+    <string name="volume_separate_notification_summary">Allow controlling each stream individually</string>
 </resources>

--- a/res/xml/sound_settings.xml
+++ b/res/xml/sound_settings.xml
@@ -97,6 +97,13 @@
         android:order="-140"
         settings:controller="com.android.settings.notification.AlarmVolumePreferenceController"/>
 
+    <!-- Separate ring & notification toggle -->
+    <SwitchPreference
+        android:key="volume_separate_notification"
+        android:title="@string/volume_separate_notification_title"
+        android:summary="@string/volume_separate_notification_summary"
+        android:order="-135"/>
+
     <!-- Increasing ring -->
     <org.derpfest.support.preferences.SystemSettingSwitchPreference
         android:key="increasing_ring"

--- a/src/com/android/settings/notification/NotificationVolumePreferenceController.java
+++ b/src/com/android/settings/notification/NotificationVolumePreferenceController.java
@@ -61,10 +61,12 @@ public class NotificationVolumePreferenceController extends
         mNormalIconId =  R.drawable.ic_notifications;
         mVibrateIconId = R.drawable.ic_volume_ringer_vibrate;
         mSilentIconId = R.drawable.ic_notifications_off_24dp;
+        mSeparateNotification = isSeparateNotificationConfigEnabled();
 
         if (updateRingerMode()) {
             updateEnabledState();
         }
+        updateVisibility();
     }
 
     /**
@@ -82,6 +84,7 @@ public class NotificationVolumePreferenceController extends
         updateEffectsSuppressor();
         selectPreferenceIconState();
         updateEnabledState();
+        updateVisibility();
     }
 
     /**
@@ -95,15 +98,18 @@ public class NotificationVolumePreferenceController extends
             if (newVal != mSeparateNotification) {
                 mSeparateNotification = newVal;
                 // Update UI if config change happens when Sound Settings page is on the foreground
-                if (mPreference != null) {
-                    int status = getAvailabilityStatus();
-                    mPreference.setVisible(status == AVAILABLE
-                            || status == DISABLED_DEPENDENT_SETTING);
-                    if (status == DISABLED_DEPENDENT_SETTING) {
-                        mPreference.setEnabled(false);
-                    }
-                }
+                updateVisibility();
             }
+        }
+    }
+
+    private void updateVisibility() {
+        if (mPreference == null) return;
+        int status = getAvailabilityStatus();
+        mPreference.setVisible(status == AVAILABLE
+                || status == DISABLED_DEPENDENT_SETTING);
+        if (status == DISABLED_DEPENDENT_SETTING) {
+            mPreference.setEnabled(false);
         }
     }
 
@@ -133,7 +139,7 @@ public class NotificationVolumePreferenceController extends
                 && !mHelper.isSingleVolume() && separateNotification
                 ? (mRingerMode == AudioManager.RINGER_MODE_NORMAL
                     ? AVAILABLE : DISABLED_DEPENDENT_SETTING)
-                : UNSUPPORTED_ON_DEVICE;
+                : CONDITIONALLY_UNAVAILABLE;
     }
 
     @Override

--- a/src/com/android/settings/notification/RingVolumePreferenceController.java
+++ b/src/com/android/settings/notification/RingVolumePreferenceController.java
@@ -63,6 +63,9 @@ public class RingVolumePreferenceController extends
 
         mSeparateNotification = isSeparateNotificationConfigEnabled();
         updateRingerMode();
+        if (mPreference != null) {
+            mPreference.setVisible(getAvailabilityStatus() == AVAILABLE);
+        }
     }
 
     /**
@@ -75,6 +78,9 @@ public class RingVolumePreferenceController extends
             if (valueUpdated) {
                 updateEffectsSuppressor();
                 selectPreferenceIconState();
+                if (mPreference != null) {
+                    mPreference.setVisible(getAvailabilityStatus() == AVAILABLE);
+                }
             }
         }
     }
@@ -114,7 +120,7 @@ public class RingVolumePreferenceController extends
     public int getAvailabilityStatus() {
         boolean separateNotification = isSeparateNotificationConfigEnabled();
         return !separateNotification && !mHelper.isSingleVolume()
-                ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+                ? AVAILABLE : CONDITIONALLY_UNAVAILABLE;
     }
 
     @Override

--- a/src/com/android/settings/notification/SeparateRingVolumePreferenceController.java
+++ b/src/com/android/settings/notification/SeparateRingVolumePreferenceController.java
@@ -62,6 +62,9 @@ public class SeparateRingVolumePreferenceController extends
 
         mSeparateNotification = isSeparateNotificationConfigEnabled();
         updateRingerMode();
+        if (mPreference != null) {
+            mPreference.setVisible(getAvailabilityStatus() == AVAILABLE);
+        }
     }
 
     /**
@@ -74,6 +77,9 @@ public class SeparateRingVolumePreferenceController extends
             if (valueUpdated) {
                 updateEffectsSuppressor();
                 selectPreferenceIconState();
+                if (mPreference != null) {
+                    mPreference.setVisible(getAvailabilityStatus() == AVAILABLE);
+                }
             }
         }
     }
@@ -111,7 +117,7 @@ public class SeparateRingVolumePreferenceController extends
     public int getAvailabilityStatus() {
         boolean separateNotification = isSeparateNotificationConfigEnabled();
         return separateNotification && !mHelper.isSingleVolume()
-                ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+                ? AVAILABLE : CONDITIONALLY_UNAVAILABLE;
     }
 
     @Override

--- a/src/com/android/settings/notification/SoundSettings.java
+++ b/src/com/android/settings/notification/SoundSettings.java
@@ -39,6 +39,7 @@ import com.android.settings.core.OnActivityResultListener;
 import com.android.settings.dashboard.DashboardFragment;
 import com.android.settings.search.BaseSearchIndexProvider;
 import com.android.settings.sound.HandsFreeProfileOutputPreferenceController;
+import com.android.settings.sound.SeparateNotificationPreferenceController;
 import com.android.settings.widget.PreferenceCategoryController;
 import com.android.settingslib.core.AbstractPreferenceController;
 import com.android.settingslib.core.instrumentation.Instrumentable;
@@ -283,6 +284,12 @@ public class SoundSettings extends DashboardFragment implements OnActivityResult
         controllers.add(new NotificationRingtonePreferenceController(context));
         controllers.add(new IncreasingRingPreferenceController(context));
         controllers.add(new IncreasingRingVolumePreferenceController(context));
+
+        // === Other Sound Settings ===
+        final SeparateNotificationPreferenceController separateNotificationPreferenceController =
+                new SeparateNotificationPreferenceController(context);
+
+        controllers.add(separateNotificationPreferenceController);
 
         return controllers;
     }

--- a/src/com/android/settings/notification/VolumeSeekBarPreferenceController.java
+++ b/src/com/android/settings/notification/VolumeSeekBarPreferenceController.java
@@ -54,9 +54,7 @@ public abstract class VolumeSeekBarPreferenceController extends
     @Override
     public void displayPreference(PreferenceScreen screen) {
         super.displayPreference(screen);
-        if (isAvailable()) {
-            setupVolPreference(screen);
-        }
+        setupVolPreference(screen);
     }
 
     protected void setupVolPreference(PreferenceScreen screen) {

--- a/src/com/android/settings/sound/SeparateNotificationPreferenceController.java
+++ b/src/com/android/settings/sound/SeparateNotificationPreferenceController.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2023 Yet Another AOSP Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.android.settings.sound;
+
+import android.content.Context;
+import android.provider.DeviceConfig;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.SwitchPreference;
+
+import com.android.settings.R;
+import com.android.settingslib.core.AbstractPreferenceController;
+
+/**
+ * A simple preference controller to allow splitting notification and ringtone streams
+ */
+public class SeparateNotificationPreferenceController extends AbstractPreferenceController
+        implements Preference.OnPreferenceChangeListener {
+
+    private static final String KEY = "volume_separate_notification";
+
+    private SwitchPreference mPreference;
+
+    public SeparateNotificationPreferenceController(Context context) {
+        super(context);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public String getPreferenceKey() {
+        return KEY;
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        mPreference = (SwitchPreference) screen.findPreference(KEY);
+        mPreference.setChecked(getDeviceConfig(KEY));
+        mPreference.setOnPreferenceChangeListener(this);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        if (preference == mPreference) {
+            final boolean value = (Boolean) newValue;
+            updateDeviceConfig(KEY, value);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean getDeviceConfig(String key) {
+        return DeviceConfig.getBoolean(DeviceConfig.NAMESPACE_SYSTEMUI, key, false);
+    }
+
+    private void updateDeviceConfig(String key, boolean enabled) {
+        DeviceConfig.setProperty(DeviceConfig.NAMESPACE_SYSTEMUI,
+                key, String.valueOf(enabled), false /* makeDefault */);
+    }
+}


### PR DESCRIPTION
Using the newly added device config (QPR3).
AOSP have already implemented listeners for this to be runtime, but it seems like they never tested settings side properly - especially when the toggle is at the same page. After fixing some funny logic errors it now updates just fine. base side needs no extra modifications, the observers there are programmed correctly.